### PR TITLE
hal: Command queues submission via references to command buffers

### DIFF
--- a/examples/hal/quad/main.rs
+++ b/examples/hal/quad/main.rs
@@ -455,7 +455,7 @@ fn main() {
     // copy buffer to texture
     {
         let submit = {
-            let mut cmd_buffer = command_pool.acquire_command_buffer();
+            let mut cmd_buffer = command_pool.acquire_command_buffer(false);
 
             let image_barrier = m::Barrier::Image {
                 states: (i::Access::empty(), i::ImageLayout::Undefined) ..
@@ -494,7 +494,7 @@ fn main() {
         };
 
         let submission = Submission::new()
-            .submit(&[submit]);
+            .submit(vec![submit]);
         queue.submit(submission, Some(&mut frame_fence));
 
         device.wait_for_fences(&[&frame_fence], d::WaitFor::All, !0);
@@ -523,7 +523,7 @@ fn main() {
 
         // Rendering
         let submit = {
-            let mut cmd_buffer = command_pool.acquire_command_buffer();
+            let mut cmd_buffer = command_pool.acquire_command_buffer(false);
 
             cmd_buffer.set_viewports(&[viewport.clone()]);
             cmd_buffer.set_scissors(&[viewport.rect]);
@@ -546,7 +546,7 @@ fn main() {
 
         let submission = Submission::new()
             .wait_on(&[(&mut frame_semaphore, PipelineStage::BOTTOM_OF_PIPE)])
-            .submit(&[submit]);
+            .submit(vec![submit]);
         queue.submit(submission, Some(&mut frame_fence));
 
         // TODO: replace with semaphore

--- a/examples/hal/quad/main.rs
+++ b/examples/hal/quad/main.rs
@@ -494,7 +494,7 @@ fn main() {
         };
 
         let submission = Submission::new()
-            .submit(vec![submit]);
+            .submit(Some(submit));
         queue.submit(submission, Some(&mut frame_fence));
 
         device.wait_for_fences(&[&frame_fence], d::WaitFor::All, !0);
@@ -546,7 +546,7 @@ fn main() {
 
         let submission = Submission::new()
             .wait_on(&[(&mut frame_semaphore, PipelineStage::BOTTOM_OF_PIPE)])
-            .submit(vec![submit]);
+            .submit(Some(submit));
         queue.submit(submission, Some(&mut frame_fence));
 
         // TODO: replace with semaphore

--- a/src/backend/vulkan/src/command.rs
+++ b/src/backend/vulkan/src/command.rs
@@ -901,7 +901,8 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
         &mut self,
         buffers: I,
     ) where
-        I: Iterator<Item=&'a CommandBuffer>
+        I: IntoIterator,
+        I::Item: Borrow<CommandBuffer>,
     {
         unimplemented!()
     }

--- a/src/backend/vulkan/src/command.rs
+++ b/src/backend/vulkan/src/command.rs
@@ -86,7 +86,7 @@ impl CommandBuffer {
 }
 
 impl com::RawCommandBuffer<Backend> for CommandBuffer {
-    fn begin(&mut self) {
+    fn begin(&mut self, flags: com::CommandBufferFlags) {
         let info = vk::CommandBufferBeginInfo {
             s_type: vk::StructureType::CommandBufferBeginInfo,
             p_next: ptr::null(),
@@ -895,6 +895,15 @@ impl com::RawCommandBuffer<Backend> for CommandBuffer {
                 constants,
             );
         }
+    }
+
+    fn execute_commands<'a, I>(
+        &mut self,
+        buffers: I,
+    ) where
+        I: Iterator<Item=&'a CommandBuffer>
+    {
+        unimplemented!()
     }
 }
 

--- a/src/hal/src/command/mod.rs
+++ b/src/hal/src/command/mod.rs
@@ -104,7 +104,7 @@ impl<'a, B: Backend, C, S: Shot> CommandBuffer<'a, B, C, S, Primary> {
         I::Item: Submittable<B, K, Secondary>,
         C: Supports<K>,
     {
-        let submits = submits.into_iter().map(|submit| submit).collect::<Vec<_>>();
+        let submits = submits.into_iter().collect::<Vec<_>>();
         self.raw.execute_commands(submits.iter().map(|submit| unsafe { submit.as_buffer() }));
     }
 }

--- a/src/hal/src/command/mod.rs
+++ b/src/hal/src/command/mod.rs
@@ -17,7 +17,7 @@ pub use self::renderpass::*;
 pub use self::transfer::*;
 
 /// Trait indicating how many times a Submit can be submitted.
-pub trait Shot { 
+pub trait Shot {
     ///
     const FLAGS: CommandBufferFlags;
 }
@@ -37,12 +37,6 @@ impl Level for Primary { }
 pub enum Secondary { }
 impl Level for Secondary { }
 
-/// A trait representing a command buffer that can be added to a `Submission`.
-pub unsafe trait Submittable<B: Backend, C, L: Level> {
-    ///
-    unsafe fn into_buffer(self) -> B::CommandBuffer;
-}
-
 /// Thread-safe finished command buffer for submission.
 pub struct Submit<B: Backend, C, S: Shot, L: Level>(pub(crate) B::CommandBuffer, pub(crate) PhantomData<(C, S, L)>);
 impl<B: Backend, C, S: Shot, L: Level> Submit<B, C, S, L> {
@@ -50,21 +44,26 @@ impl<B: Backend, C, S: Shot, L: Level> Submit<B, C, S, L> {
         Submit(buffer, PhantomData)
     }
 }
+unsafe impl<B: Backend, C, S: Shot, L: Level> Send for Submit<B, C, S, L> {}
 
+/// A trait representing a command buffer that can be added to a `Submission`.
+pub unsafe trait Submittable<B: Backend, C, L: Level> {
+    ///
+    unsafe fn as_buffer(&self) -> &B::CommandBuffer;
+}
 unsafe impl<B: Backend, C, L: Level> Submittable<B, C, L> for Submit<B, C, OneShot, L> {
-    unsafe fn into_buffer(self) -> B::CommandBuffer { self.0 }
+    unsafe fn as_buffer(&self) -> &B::CommandBuffer { &self.0 }
 }
 unsafe impl<'a, B: Backend, C, L: Level> Submittable<B, C, L> for &'a Submit<B, C, MultiShot, L> {
-    unsafe fn into_buffer(self) -> B::CommandBuffer { self.0.clone() }
+    unsafe fn as_buffer(&self) -> &B::CommandBuffer { &self.0 }
 }
-unsafe impl<B: Backend, C, S: Shot, L: Level> Send for Submit<B, C, S, L> {}
 
 /// A convenience for not typing out the full signature of a secondary command buffer.
 pub type SecondaryCommandBuffer<'a, B: Backend, C, S: Shot = OneShot> = CommandBuffer<'a, B, C, S, Secondary>;
 
 /// Command buffer with compute, graphics and transfer functionality.
 pub struct CommandBuffer<'a, B: Backend, C, S: Shot = OneShot, L: Level = Primary> {
-    pub(crate) raw: &'a mut B::CommandBuffer, 
+    pub(crate) raw: &'a mut B::CommandBuffer,
     pub(crate) _marker: PhantomData<(C, S, L)>
 }
 
@@ -72,7 +71,7 @@ impl<'a, B: Backend, C, S: Shot, L: Level> CommandBuffer<'a, B, C, S, L> {
     /// Create a new typed command buffer from a raw command pool.
     pub unsafe fn new(raw: &'a mut B::CommandBuffer) -> Self {
         CommandBuffer {
-            raw: raw, 
+            raw: raw,
             _marker: PhantomData,
         }
     }
@@ -86,7 +85,7 @@ impl<'a, B: Backend, C, S: Shot, L: Level> CommandBuffer<'a, B, C, S, L> {
     }
 
     /// Downgrade a command buffer to a lesser capability type.
-    /// 
+    ///
     /// This is safe as you can't `submit` downgraded version since `submit`
     /// requires `self` by move.
     pub fn downgrade<D>(&mut self) -> &mut CommandBuffer<'a, B, D, S>
@@ -99,13 +98,14 @@ impl<'a, B: Backend, C, S: Shot, L: Level> CommandBuffer<'a, B, C, S, L> {
 
 impl<'a, B: Backend, C, S: Shot> CommandBuffer<'a, B, C, S, Primary> {
     ///
-    pub fn execute_commands<I, K>(&mut self, submits: I) 
+    pub fn execute_commands<I, K>(&mut self, submits: I)
     where
-        I: Iterator,
+        I: IntoIterator,
         I::Item: Submittable<B, K, Secondary>,
         C: Supports<K>,
     {
-        self.raw.execute_commands(submits.map(|submit| unsafe { submit.into_buffer() }));
+        let submits = submits.into_iter().map(|submit| submit).collect::<Vec<_>>();
+        self.raw.execute_commands(submits.iter().map(|submit| unsafe { submit.as_buffer() }));
     }
 }
 

--- a/src/hal/src/command/raw.rs
+++ b/src/hal/src/command/raw.rs
@@ -350,5 +350,6 @@ pub trait RawCommandBuffer<B: Backend>: Clone + Send {
         &mut self,
         buffers: I,
     ) where
-        I: Iterator<Item=&'a B::CommandBuffer>;
+        I: IntoIterator,
+        I::Item: Borrow<B::CommandBuffer>;
 }

--- a/src/hal/src/command/raw.rs
+++ b/src/hal/src/command/raw.rs
@@ -346,9 +346,9 @@ pub trait RawCommandBuffer<B: Backend>: Clone + Send {
     );
 
     ///
-    fn execute_commands<I>(
+    fn execute_commands<'a, I>(
         &mut self,
         buffers: I,
-    ) where 
-        I: Iterator<Item=B::CommandBuffer>;
+    ) where
+        I: Iterator<Item=&'a B::CommandBuffer>;
 }

--- a/src/hal/src/command/renderpass.rs
+++ b/src/hal/src/command/renderpass.rs
@@ -219,7 +219,7 @@ impl<'a, B: Backend> RenderPassSecondaryEncoder<'a, B> {
         I: IntoIterator<Item=S>,
         S: Submittable<B, Subpass, Secondary>,
     {
-        let submits = submits.into_iter().map(|submit| submit).collect::<Vec<_>>();
+        let submits = submits.into_iter().collect::<Vec<_>>();
         self.0.as_mut().unwrap().execute_commands(submits.iter().map(|submit| unsafe { submit.as_buffer() }));
     }
 

--- a/src/hal/src/command/renderpass.rs
+++ b/src/hal/src/command/renderpass.rs
@@ -214,12 +214,13 @@ impl<'a, B: Backend> RenderPassSecondaryEncoder<'a, B> {
     }
 
     ///
-    pub fn execute_commands<I, S>(&mut self, submits: I) 
+    pub fn execute_commands<I, S>(&mut self, submits: I)
     where
-        I: Iterator<Item=S>,
+        I: IntoIterator<Item=S>,
         S: Submittable<B, Subpass, Secondary>,
     {
-        self.0.as_mut().unwrap().execute_commands(submits.map(|submit| unsafe { submit.into_buffer() }));
+        let submits = submits.into_iter().map(|submit| submit).collect::<Vec<_>>();
+        self.0.as_mut().unwrap().execute_commands(submits.iter().map(|submit| unsafe { submit.as_buffer() }));
     }
 
     ///
@@ -277,4 +278,3 @@ impl<B: Backend, S: Shot> Drop for SubpassCommandBuffer<B, S> {
         (self.0).0.finish();
     }
 }
-

--- a/src/hal/src/queue/mod.rs
+++ b/src/hal/src/queue/mod.rs
@@ -11,6 +11,7 @@ pub mod capability;
 pub mod submission;
 
 use Backend;
+use std::borrow::Borrow;
 use std::fmt::Debug;
 use std::marker::PhantomData;
 
@@ -113,7 +114,10 @@ pub trait RawCommandQueue<B: Backend> {
     /// Unsafe because it's not checked that the queue can process the submitted command buffers.
     /// Trying to submit compute commands to a graphics queue will result in undefined behavior.
     /// Each queue implements safe wrappers according to their supported functionalities!
-    unsafe fn submit_raw(&mut self, RawSubmission<B>, Option<&B::Fence>);
+    unsafe fn submit_raw<IC>(&mut self, RawSubmission<B, IC>, Option<&B::Fence>)
+    where
+        IC: IntoIterator,
+        IC::Item: Borrow<B::CommandBuffer>;
 }
 
 /// Stronger-typed and safer `CommandQueue` wraps around `RawCommandQueue`.


### PR DESCRIPTION
cc @AlphaModder @kvark

Adjust interface so that command queues can take references to command buffers.
Biggest issue is to adjust the higher level submission builder. Split building process into `submit` and `submit_reusables` to take different kind of command buffers.